### PR TITLE
Add simple landing page

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ lazy val `latis-hapi` = (project in file("."))
     libraryDependencies ++= Seq(
       "org.http4s"    %% "http4s-blaze-server" % http4sVersion,
       "org.http4s"    %% "http4s-dsl"          % http4sVersion,
-      "ch.qos.logback" % "logback-classic"     % "1.2.3" % Runtime
+      "ch.qos.logback" % "logback-classic"     % "1.2.3" % Runtime,
+      "com.lihaoyi"   %% "scalatags"           % "0.6.7"
     )
   )
 

--- a/src/main/scala/latis/server/HapiService.scala
+++ b/src/main/scala/latis/server/HapiService.scala
@@ -1,15 +1,50 @@
 package latis.server
 
 import cats.effect.Effect
+import cats.implicits._
 import org.http4s.HttpService
+import org.http4s.MediaType.`text/html`
 import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.`Content-Type`
+import scalatags.Text.all._
 
 /** Implements the `/hapi` endpoint. */
 class HapiService[F[_]: Effect] extends Http4sDsl[F] {
 
+  val landingPage: Frag =
+    html(
+      body(
+        h1("LASP HAPI Server"),
+        p("""This server supports the HAPI 2.0 specification for
+        |delivery of time series data. The server consists of the
+        |following 4 REST-like endpoints that will respond to HTTP GET
+        |requests:""".stripMargin.replaceAll("\n", " ")),
+        ul(
+          li(
+            a(href := "hapi/capabilities")("capabilities"),
+            " - list the output formats the server can emit"
+          ),
+          li(
+            a(href := "hapi/catalog")("catalog"),
+            " - list the datasets that are available"
+          ),
+          li(
+            a(href := "hapi/info")("info"),
+            " - describe a dataset"
+          ),
+          li(
+            a(href := "hapi/data")("data"),
+            " - stream content of a dataset"
+          )
+        )
+      )
+    )
+
   val service: HttpService[F] =
     HttpService[F] {
       case GET -> Root / "hapi" =>
-        Ok("Hello from HAPI!")
+        Ok(landingPage.render).map {
+          _.withContentType(`Content-Type`(`text/html`))
+        }
     }
 }


### PR DESCRIPTION
This landing page is based on the example given in the HAPI 2.0 spec.

I'm not interested in the wording at the moment unless something is terribly wrong. We will revisit the content on the page later. This is mostly about the scaffolding to get *something* there.

I went ahead and pulled in a dependency on [ScalaTags](https://www.lihaoyi.com/scalatags) now rather than wait until we're actually dynamically generating content.

Resolves #3.