### PR TITLE
Implement capabilities endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,13 @@ lazy val `latis-hapi` = (project in file("."))
     name := "latis-hapi",
     libraryDependencies ++= Seq(
       "org.http4s"    %% "http4s-blaze-server" % http4sVersion,
+      "org.http4s"    %% "http4s-circe"        % http4sVersion,
       "org.http4s"    %% "http4s-dsl"          % http4sVersion,
       "ch.qos.logback" % "logback-classic"     % "1.2.3" % Runtime,
-      "com.lihaoyi"   %% "scalatags"           % "0.6.7"
-    )
+      "com.lihaoyi"   %% "scalatags"           % "0.6.7",
+      "org.scalatest" %% "scalatest"           % "3.0.5" % Test
+    ),
+    Test / logBuffered := false
   )
 
 lazy val compilerFlags = Seq(

--- a/src/main/scala/latis/server/CapabilitiesService.scala
+++ b/src/main/scala/latis/server/CapabilitiesService.scala
@@ -1,7 +1,10 @@
 package latis.server
 
 import cats.effect.Effect
+import io.circe.Encoder
+import io.circe.syntax._
 import org.http4s.HttpService
+import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 
 /** Implements the `/capabilities` endpoint. */
@@ -10,6 +13,34 @@ class CapabilitiesService[F[_]: Effect] extends Http4sDsl[F] {
   val service: HttpService[F] =
     HttpService[F] {
       case GET -> Root / "capabilities" =>
-        Ok("Hello from HAPI!")
+        Ok(
+          Capabilities(
+            HapiServer.version,
+            Status.`1200`,
+            List("binary", "csv", "json")
+          ).asJson
+        )
+    }
+}
+
+/**
+ * Response from the `/capabilities` endpoint.
+ *
+ * @param version version of HAPI
+ * @param status HAPI status object
+ * @param formats list of supported formats
+ */
+final case class Capabilities(
+  version: String,
+  status: Status,
+  formats: List[String]
+)
+
+object Capabilities {
+
+  /** JSON encoder */
+  implicit val encoder: Encoder[Capabilities] =
+    Encoder.forProduct3("HAPI", "status", "outputFormats") { x =>
+      (x.version, x.status, x.formats)
     }
 }

--- a/src/main/scala/latis/server/HapiServer.scala
+++ b/src/main/scala/latis/server/HapiServer.scala
@@ -16,7 +16,11 @@ import org.http4s.server.blaze._
  *
  * This is the entry point for the HAPI server.
  */
-object HapiServer extends HapiServerApp[IO]
+object HapiServer extends HapiServerApp[IO] {
+
+  /** Version of HAPI spec. */
+  val version: String = "2.0"
+}
 
 /** The HAPI server parameterized over the effect type. */
 abstract class HapiServerApp[F[_]: Effect] extends StreamApp[F] {

--- a/src/main/scala/latis/server/Status.scala
+++ b/src/main/scala/latis/server/Status.scala
@@ -1,5 +1,7 @@
 package latis.server
 
+import io.circe.Encoder
+
 /** Representation of a HAPI status code and message. */
 final case class Status(code: Int, message: String)
 
@@ -19,4 +21,10 @@ object Status {
   val `1410`: Status = Status(1410, "Bad request - unsupported include value")
   val `1500`: Status = Status(1500, "Internal server error")
   val `1501`: Status = Status(1501, "Internal server error - upstream request error")
+
+  /** JSON encoder */
+  implicit val encoder: Encoder[Status] =
+    Encoder.forProduct2("code", "message") { x =>
+      (x.code, x.message)
+    }
 }

--- a/src/test/scala/latis/server/CapabilitiesServiceSpec.scala
+++ b/src/test/scala/latis/server/CapabilitiesServiceSpec.scala
@@ -1,0 +1,38 @@
+package latis.server
+
+import cats.effect.IO
+import io.circe._
+import io.circe.syntax._
+import org.http4s._
+import org.http4s.implicits._
+import org.scalatest.FlatSpec
+
+class CapabilitiesServiceSpec extends FlatSpec {
+
+  "The capabilities service" should "advertise all output options" in {
+    val req = Request[IO](Method.GET, Uri.uri("/capabilities"))
+
+    val expected = Json.obj(
+      ("HAPI", Json.fromString(HapiServer.version)),
+      ("status", Status.`1200`.asJson),
+      ("outputFormats", Json.fromValues(
+        List(
+          Json.fromString("binary"),
+          Json.fromString("csv"),
+          Json.fromString("json")
+        )
+      ))
+    )
+
+
+    val body = {
+      val capabilities = new CapabilitiesService[IO]()
+      // False error
+      capabilities.service.orNotFound(req).flatMap { res =>
+        // The stream ought to contain only the body.
+        res.bodyAsText.compile.toList.map(_.head)
+      }.unsafeRunSync
+    }
+    assert(body == expected.noSpaces)
+  }
+}


### PR DESCRIPTION
I've implemented the [capabilities endpoint](https://github.com/hapi-server/data-specification/blob/master/hapi-2.0.0/HAPI-data-access-spec-2.0.0.md#capabilities) with the assumption that we will support all of the standard HAPI outputs.

I imagine in the future we might revisit this so the list of outputs is dynamically generated and includes custom output formats. (Though it isn't clear to me how the custom formats are expected to behave.)

I've also left these two commits separate for the purpose of this review:
- [6a014c0](https://github.com/lasp/latis-hapi/pull/21/commits/6a014c0f107f28e25d47268224779fe8da639d3a) : tests implemented with [uTest](https://github.com/lihaoyi/utest)
- [38fec45](https://github.com/lasp/latis-hapi/pull/21/commits/38fec45654ae505d1a7f988048eff5cf31fb6f6f) : tests implemented with [ScalaTest](http://www.scalatest.org/)

I'm curious what you think about the two libraries. uTest is meant to be more minimal, which appeals to me. However, ScalaTest is pretty widely used.

Resolves #4.