### PR TITLE
Add types for catalog endpoint responses

### DIFF
--- a/src/main/scala/latis/server/CatalogService.scala
+++ b/src/main/scala/latis/server/CatalogService.scala
@@ -1,6 +1,7 @@
 package latis.server
 
 import cats.effect.Effect
+import io.circe.Encoder
 import org.http4s.HttpService
 import org.http4s.dsl.Http4sDsl
 
@@ -11,5 +12,60 @@ class CatalogService[F[_]: Effect] extends Http4sDsl[F] {
     HttpService[F] {
       case GET -> Root / "catalog" =>
         Ok("Hello from HAPI!")
+    }
+}
+
+/**
+ * Representation of a HAPI catalog.
+ *
+ * @param version version of HAPI
+ * @param status HAPI status object
+ * @param catalog list of available datasets
+ */
+final case class Catalog(
+  version: String,
+  status: Status,
+  catalog: List[Dataset]
+)
+
+object Catalog {
+
+  /** JSON encoder */
+  implicit val encoder: Encoder[Catalog] =
+    Encoder.forProduct3("HAPI", "status", "catalog") { x =>
+      (x.version, x.status, x.catalog)
+    }
+}
+
+/**
+ * Representation of a dataset in the HAPI catalog.
+ *
+ * @param id computer-friendly identifier
+ * @param name human-friendly name
+ *
+ */
+final case class Dataset(
+  id: String,
+  name: String
+)
+
+object Dataset {
+
+  /**
+   * Constructor for datasets with only an ID.
+   *
+   * According to the spec, datasets without names must re-use the ID
+   * as a name, which this constructor enforces.
+   *
+   * @param id computer-friendly identifier
+   *
+   */
+  def apply(id: String): Dataset =
+    Dataset(id, id)
+
+  /** JSON encoder */
+  implicit val encoder: Encoder[Dataset] =
+    Encoder.forProduct2("id", "name") { x =>
+      (x.id, x.name)
     }
 }

--- a/src/test/scala/latis/server/CatalogServiceSpec.scala
+++ b/src/test/scala/latis/server/CatalogServiceSpec.scala
@@ -1,0 +1,13 @@
+package latis.server
+
+import org.scalatest.FlatSpec
+
+class CatalogServiceSpec extends FlatSpec {
+
+  "A dataset" should "default to using the ID as the name" in {
+    val id = "id"
+    val ds = Dataset(id)
+
+    assert(ds.name == id)
+  }
+}


### PR DESCRIPTION
I've added the `Catalog` and `Dataset` types (and their JSON encoders) for responses from the `catalog` endpoint.

I recognize we have another (much more important) `Dataset` type, but I think after #17 the package structure will change enough to differentiate them even more.

Resolves #6.