### PR TITLE
Add types for 'data' requests

### DIFF
--- a/src/main/scala/latis/server/DataService.scala
+++ b/src/main/scala/latis/server/DataService.scala
@@ -13,3 +13,22 @@ class DataService[F[_]: Effect] extends Http4sDsl[F] {
         Ok("Hello from HAPI!")
     }
 }
+
+/**
+ * Represents a request for data.
+ *
+ * @param id HAPI dataset ID
+ * @param minTime lower time bound (inclusive)
+ * @param maxTime upper time bound (exclusive)
+ * @param parameters list of parameter names to return
+ * @param header whether to include the metadata header
+ * @param format output format
+ */
+final case class DataRequest(
+  id: String,
+  minTime: String,
+  maxTime: String,
+  parameters: Option[List[String]],
+  header: Boolean,
+  format: String
+)

--- a/src/main/scala/latis/server/DataService.scala
+++ b/src/main/scala/latis/server/DataService.scala
@@ -2,20 +2,32 @@ package latis.server
 
 import cats.effect.Effect
 import cats.implicits._
+import io.circe.syntax._
 import org.http4s.HttpService
 import org.http4s.ParseFailure
 import org.http4s.QueryParamDecoder
 import org.http4s.QueryParameterValue
+import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.dsl.io._
 
 /** Implements the `/data` endpoint. */
 class DataService[F[_]: Effect] extends Http4sDsl[F] {
+  import QueryDecoders._
 
   val service: HttpService[F] =
     HttpService[F] {
-      case GET -> Root / "data" =>
+      case GET -> Root / "data"
+          :? IdMatcher(_)
+          +& MinTimeMatcher(_)
+          +& MaxTimeMatcher(_)
+          +& ParamMatcher(_)
+          +& IncludeMatcher(_)
+          +& FormatMatcher(_) =>
         Ok("Hello from HAPI!")
+      // Return a 1400 error if the required parameters are not given.
+      case GET -> Root / "data" :? _ =>
+        BadRequest(Status.`1400`.asJson)
     }
 }
 

--- a/src/main/scala/latis/server/DataService.scala
+++ b/src/main/scala/latis/server/DataService.scala
@@ -1,8 +1,13 @@
 package latis.server
 
 import cats.effect.Effect
+import cats.implicits._
 import org.http4s.HttpService
+import org.http4s.ParseFailure
+import org.http4s.QueryParamDecoder
+import org.http4s.QueryParameterValue
 import org.http4s.dsl.Http4sDsl
+import org.http4s.dsl.io._
 
 /** Implements the `/data` endpoint. */
 class DataService[F[_]: Effect] extends Http4sDsl[F] {
@@ -32,3 +37,64 @@ final case class DataRequest(
   header: Boolean,
   format: String
 )
+
+/** Wrapper for `include` parameter. */
+final case class Include(header: Boolean) extends AnyVal
+
+object Include {
+
+  implicit val includeDecoder: QueryParamDecoder[Include] =
+    new QueryParamDecoder[Include] {
+      override def decode(qpv: QueryParameterValue) = qpv.value match {
+        case "header" => Include(true).validNel
+        case _ =>
+          ParseFailure(
+            "Invalid value for 'include' parameter",
+            s"Invalid value for 'include' parameter: ${qpv.value}"
+          ).invalidNel
+      }
+    }
+}
+
+/** Wrapper for `format` parameter. */
+final case class Format(format: String) extends AnyVal
+
+object Format {
+
+  implicit val formatDecoder: QueryParamDecoder[Format] =
+    new QueryParamDecoder[Format] {
+      override def decode(qpv: QueryParameterValue) = qpv.value match {
+        case fmt @ ("csv" | "binary" | "json") => Format(fmt).validNel
+        case _ =>
+          ParseFailure(
+            "Invalid value for 'format' parameter",
+            s"Invalid value for 'format' parameter: ${qpv.value}"
+          ).invalidNel
+      }
+    }
+}
+
+object QueryDecoders {
+
+  object IdMatcher extends QueryParamDecoderMatcher[String]("id")
+  object MinTimeMatcher extends QueryParamDecoderMatcher[String]("time.min")
+  object MaxTimeMatcher extends QueryParamDecoderMatcher[String]("time.max")
+  object ParamMatcher extends OptionalQueryParamDecoderMatcher[List[String]]("parameters")
+  object IncludeMatcher extends OptionalQueryParamDecoderMatcher[Include]("include")
+  object FormatMatcher extends OptionalQueryParamDecoderMatcher[Format]("format")
+
+  /** Decoder for simple CSV query parameters. */
+  implicit def csvDecoder[A : QueryParamDecoder]: QueryParamDecoder[List[A]] =
+    new QueryParamDecoder[List[A]] {
+      override def decode(qpv: QueryParameterValue) =
+        if (qpv.value.isEmpty) {
+          ParseFailure(
+            "Empty parameter list.", "Empty parameter list."
+          ).invalidNel
+        } else {
+          qpv.value.split(',').toList.traverse { x =>
+            QueryParamDecoder[A].decode(QueryParameterValue(x))
+          }
+        }
+    }
+}

--- a/src/test/scala/latis/server/DataServiceSpec.scala
+++ b/src/test/scala/latis/server/DataServiceSpec.scala
@@ -1,0 +1,55 @@
+package latis.server
+
+import org.http4s.QueryParameterValue
+import org.scalatest.FlatSpec
+
+class DataServiceSpec extends FlatSpec {
+
+  "The 'include' parameter" should "accept 'header'" in {
+    val decoded = Include.includeDecoder.decode(QueryParameterValue("header"))
+    decoded.fold(_ => fail, x => assert(x.header))
+  }
+
+  it should "reject other arguments" in {
+    val decoded = Include.includeDecoder.decode(QueryParameterValue("yolo"))
+    decoded.fold(_ => succeed, _ => fail("Accepted bad input."))
+  }
+
+  "The 'format' parameter" should "accept 'csv'" in {
+    val fmt = "csv"
+    val decoded = Format.formatDecoder.decode(QueryParameterValue(fmt))
+    decoded.fold(_ => fail, x => assert(x.format == fmt))
+  }
+
+  it should "accept 'binary'" in {
+    val fmt = "binary"
+    val decoded = Format.formatDecoder.decode(QueryParameterValue(fmt))
+    decoded.fold(_ => fail, x => assert(x.format == fmt))
+  }
+
+  it should "accept 'json'" in {
+    val fmt = "json"
+    val decoded = Format.formatDecoder.decode(QueryParameterValue(fmt))
+    decoded.fold(_ => fail, x => assert(x.format == fmt))
+  }
+
+  it should "reject other arguments" in {
+    val decoded = Format.formatDecoder.decode(QueryParameterValue("yolo"))
+    decoded.fold(_ => succeed, _ => fail("Accepted bad input."))
+  }
+
+  "The 'parameters' parameter" should "accept a list of parameter names" in {
+    val params = List("a", "b", "c")
+    val decoded = QueryDecoders.csvDecoder[String].decode(
+      QueryParameterValue(params.mkString(","))
+    )
+    decoded.fold(_ => fail, x => assert(x == params))
+  }
+
+  it should "reject an empty parameter list" in {
+    val decoded = QueryDecoders.csvDecoder[String].decode(
+      QueryParameterValue("")
+    )
+    decoded.fold(_ => succeed, _ => fail("Accepted empty parameter list."))
+  }
+}


### PR DESCRIPTION
The main thrust of this was adding the `DataRequest` type.

On top of that, I've added instances of the `QueryParamDecoder` typeclass for some of the things in the `DataRequest` object so we can pull them from queries and see how parsing the queries behaves. I don't think any of the behavior with respect to the queries goes against the spec, but the behavior could be improved. I'll make other tickets for that.

There's a lot of refactoring that will need to be done as the other endpoints are fleshed out, so the places things are now will likely change to make more sense. I just need them here now.

Resolves #9.